### PR TITLE
Makefile fixes

### DIFF
--- a/sample_c/Makefile
+++ b/sample_c/Makefile
@@ -9,7 +9,7 @@ service:
 
 bundle: service
 	mkdir -p service/rw
-	rm scripts/*.pyc
+	rm -f scripts/*.pyc
 	rm -f ../$(SERVICE).tgz
 	tar caf ../$(SERVICE).tgz *
 	@echo "#### Double check ../$(SERVICE).tgz and submit it :) ####"

--- a/sample_c/Makefile
+++ b/sample_c/Makefile
@@ -8,6 +8,8 @@ service:
 	cp src/$(SERVICE) service/ro/
 
 bundle: service
+	mkdir -p service/rw
+	rm scripts/*.pyc
 	rm -f ../$(SERVICE).tgz
 	tar caf ../$(SERVICE).tgz *
 	@echo "#### Double check ../$(SERVICE).tgz and submit it :) ####"


### PR DESCRIPTION
- Create service/rw in case it doesn't exist. This could happen if you cloned the repository and it was empty (since empty directories aren't tracked by git).
- Delete scripts/*.pyc files since this apparently freaks out the upload service.
